### PR TITLE
feat(shards): Add multipart file upload support

### DIFF
--- a/apps/crystalshards/db/migrations/00000000000010_add_checksum_to_shard_versions.cr
+++ b/apps/crystalshards/db/migrations/00000000000010_add_checksum_to_shard_versions.cr
@@ -1,0 +1,13 @@
+class AddChecksumToShardVersions::V00000000000010 < Avram::Migrator::Migration::V1
+  def migrate
+    alter table_for(ShardVersion) do
+      add checksum : String?
+    end
+  end
+
+  def rollback
+    alter table_for(ShardVersion) do
+      remove :checksum
+    end
+  end
+end

--- a/apps/crystalshards/openapi.yml
+++ b/apps/crystalshards/openapi.yml
@@ -160,6 +160,137 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
 
+  /api/shards/upload:
+    post:
+      summary: Upload shard package
+      description: |
+        Upload a Crystal shard package via multipart form data.
+        This endpoint accepts a .tar.gz file along with shard metadata.
+        The package is uploaded directly to MinIO storage and a ShardVersion is created.
+      tags:
+        - shards
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - name
+                - version
+                - repository_url
+                - package
+              properties:
+                name:
+                  type: string
+                  description: Unique shard name (lowercase, alphanumeric with hyphens)
+                  example: my-awesome-shard
+                version:
+                  type: string
+                  description: Semantic version number
+                  example: 1.0.0
+                description:
+                  type: string
+                  description: Brief description of the shard
+                  example: A wonderful Crystal shard
+                repository_url:
+                  type: string
+                  format: uri
+                  description: Git repository URL
+                  example: https://github.com/user/my-awesome-shard
+                homepage_url:
+                  type: string
+                  format: uri
+                  description: Project homepage URL
+                  example: https://my-awesome-shard.com
+                documentation_url:
+                  type: string
+                  format: uri
+                  description: Documentation URL
+                  example: https://docs.my-awesome-shard.com
+                license:
+                  type: string
+                  description: SPDX license identifier
+                  example: MIT
+                package:
+                  type: string
+                  format: binary
+                  description: Package archive file (.tar.gz)
+                checksum:
+                  type: string
+                  description: Optional SHA256 checksum for verification (computed if not provided)
+                  example: 5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+      responses:
+        '201':
+          description: Package uploaded successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Shard uploaded successfully
+                  shard:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
+                      name:
+                        type: string
+                  version:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        format: int64
+                      version:
+                        type: string
+                      checksum:
+                        type: string
+                  checksum:
+                    type: string
+                    description: SHA256 checksum of uploaded package
+        '400':
+          description: Bad request (invalid content type, file extension, or checksum)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Package file must be a .tar.gz archive
+                  expected_checksum:
+                    type: string
+                    description: Present when checksum validation fails
+                  actual_checksum:
+                    type: string
+                    description: Present when checksum validation fails
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+        '500':
+          description: Server error (upload failure)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: Failed to upload package
+
   /api/shards/{name}:
     get:
       summary: Get shard details

--- a/apps/crystalshards/spec/requests/api/shards/upload_spec.cr
+++ b/apps/crystalshards/spec/requests/api/shards/upload_spec.cr
@@ -1,0 +1,236 @@
+require "../../../spec_helper"
+require "digest/sha256"
+
+describe Api::Shards::Upload do
+  it "uploads a package with multipart form data" do
+    # Create test package content
+    package_content = "fake tar.gz content for testing"
+    checksum = Digest::SHA256.hexdigest(package_content)
+
+    # Build multipart form data
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    builder.field("name", "multipart-shard")
+    builder.field("version", "1.0.0")
+    builder.field("description", "A test shard uploaded via multipart")
+    builder.field("repository_url", "https://github.com/user/multipart-shard")
+    builder.field("license", "MIT")
+    builder.field("checksum", checksum)
+
+    builder.file(
+      "package",
+      IO::Memory.new(package_content),
+      HTTP::FormData::FileMetadata.new(filename: "multipart-shard-1.0.0.tar.gz")
+    )
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(201)
+    json = JSON.parse(response.body)
+    json["message"].should eq("Shard uploaded successfully")
+    json["shard"]["name"].should eq("multipart-shard")
+    json["version"]["version"].should eq("1.0.0")
+    json["checksum"].should eq(checksum)
+
+    # Verify shard was created in database
+    shard = ShardQuery.new.name("multipart-shard").first?
+    shard.should_not be_nil
+    shard.try(&.description).should eq("A test shard uploaded via multipart")
+  end
+
+  it "validates required fields are present" do
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    # Only provide name (missing version, repository_url, package)
+    builder.field("name", "incomplete-shard")
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(400)
+    response.body.should contain("Missing required fields")
+  end
+
+  it "validates package file extension" do
+    package_content = "fake content"
+
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    builder.field("name", "bad-extension-shard")
+    builder.field("version", "1.0.0")
+    builder.field("repository_url", "https://github.com/user/bad-extension-shard")
+
+    builder.file(
+      "package",
+      IO::Memory.new(package_content),
+      HTTP::FormData::FileMetadata.new(filename: "package.zip")
+    )
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(400)
+    response.body.should contain("must be a .tar.gz archive")
+  end
+
+  it "validates checksum when provided" do
+    package_content = "fake tar.gz content"
+    wrong_checksum = "0000000000000000000000000000000000000000000000000000000000000000"
+
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    builder.field("name", "checksum-test-shard")
+    builder.field("version", "1.0.0")
+    builder.field("repository_url", "https://github.com/user/checksum-test-shard")
+    builder.field("checksum", wrong_checksum)
+
+    builder.file(
+      "package",
+      IO::Memory.new(package_content),
+      HTTP::FormData::FileMetadata.new(filename: "package.tar.gz")
+    )
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(400)
+    json = JSON.parse(response.body)
+    json["error"].should eq("Checksum mismatch")
+    json["expected_checksum"].should eq(wrong_checksum)
+    json["actual_checksum"].should_not eq(wrong_checksum)
+  end
+
+  it "computes checksum when not provided" do
+    package_content = "fake tar.gz content"
+
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    builder.field("name", "auto-checksum-shard")
+    builder.field("version", "1.0.0")
+    builder.field("repository_url", "https://github.com/user/auto-checksum-shard")
+
+    builder.file(
+      "package",
+      IO::Memory.new(package_content),
+      HTTP::FormData::FileMetadata.new(filename: "package.tar.gz")
+    )
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(201)
+    json = JSON.parse(response.body)
+    json["checksum"].should eq(Digest::SHA256.hexdigest(package_content))
+  end
+
+  it "rejects non-multipart content type" do
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "application/json"},
+      body: {name: "json-shard"}.to_json
+    )
+
+    response.should send_json(400)
+    response.body.should contain("Content-Type must be multipart/form-data")
+  end
+
+  it "handles optional fields correctly" do
+    package_content = "minimal package content"
+    checksum = Digest::SHA256.hexdigest(package_content)
+
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    builder.field("name", "minimal-multipart-shard")
+    builder.field("version", "1.0.0")
+    builder.field("repository_url", "https://github.com/user/minimal-multipart-shard")
+
+    builder.file(
+      "package",
+      IO::Memory.new(package_content),
+      HTTP::FormData::FileMetadata.new(filename: "package.tar.gz")
+    )
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(201)
+
+    shard = ShardQuery.new.name("minimal-multipart-shard").first?
+    shard.should_not be_nil
+    shard.try(&.description).should be_nil
+    shard.try(&.homepage_url).should be_nil
+  end
+
+  it "creates shard version with correct checksum" do
+    package_content = "versioned package content"
+    checksum = Digest::SHA256.hexdigest(package_content)
+
+    io = IO::Memory.new
+    builder = HTTP::FormData::Builder.new(io, "boundary123")
+
+    builder.field("name", "versioned-shard")
+    builder.field("version", "2.5.3")
+    builder.field("repository_url", "https://github.com/user/versioned-shard")
+
+    builder.file(
+      "package",
+      IO::Memory.new(package_content),
+      HTTP::FormData::FileMetadata.new(filename: "package.tar.gz")
+    )
+
+    builder.finish
+
+    response = ApiClient.exec(
+      Api::Shards::Upload,
+      headers: HTTP::Headers{"Content-Type" => "multipart/form-data; boundary=boundary123"},
+      body: io.to_s
+    )
+
+    response.should send_json(201)
+    json = JSON.parse(response.body)
+    version_id = json["version"]["id"].as_i64
+
+    # Verify shard version was created with checksum
+    version = ShardVersionQuery.new.id(version_id).first?
+    version.should_not be_nil
+    version.try(&.version).should eq("2.5.3")
+    version.try(&.checksum).should eq(checksum)
+  end
+end

--- a/apps/crystalshards/src/actions/api/shards/upload.cr
+++ b/apps/crystalshards/src/actions/api/shards/upload.cr
@@ -1,0 +1,132 @@
+require "../../../services/storage_service"
+require "digest/sha256"
+
+class Api::Shards::Upload < ApiAction
+  include Lucky::RateLimit
+  rate_limit to: 10, within: 1.hour
+
+  post "/api/shards/upload" do
+    # Parse multipart form data
+    if request.headers["Content-Type"]?.try(&.starts_with?("multipart/form-data"))
+      handle_multipart_upload
+    else
+      json({
+        error: "Content-Type must be multipart/form-data",
+      }, status: 400)
+    end
+  end
+
+  private def handle_multipart_upload
+    shard_name : String? = nil
+    version : String? = nil
+    description : String? = nil
+    repository_url : String? = nil
+    homepage_url : String? = nil
+    documentation_url : String? = nil
+    license : String? = nil
+    package_file : HTTP::FormData::Part? = nil
+    checksum : String? = nil
+
+    HTTP::FormData.parse(request) do |part|
+      case part.name
+      when "name"
+        shard_name = part.body.gets_to_end
+      when "version"
+        version = part.body.gets_to_end
+      when "description"
+        description = part.body.gets_to_end
+      when "repository_url"
+        repository_url = part.body.gets_to_end
+      when "homepage_url"
+        homepage_url = part.body.gets_to_end
+      when "documentation_url"
+        documentation_url = part.body.gets_to_end
+      when "license"
+        license = part.body.gets_to_end
+      when "package"
+        package_file = part
+      when "checksum"
+        checksum = part.body.gets_to_end
+      end
+    end
+
+    unless shard_name && version && repository_url && package_file
+      return json({
+        error: "Missing required fields: name, version, repository_url, and package file",
+      }, status: 400)
+    end
+
+    unless package_file.filename.try(&.ends_with?(".tar.gz"))
+      return json({
+        error: "Package file must be a .tar.gz archive",
+      }, status: 400)
+    end
+
+    package_content = package_file.body.gets_to_end
+    computed_checksum = Digest::SHA256.hexdigest(package_content)
+
+    if checksum && checksum != computed_checksum
+      return json({
+        error:             "Checksum mismatch",
+        expected_checksum: checksum,
+        actual_checksum:   computed_checksum,
+      }, status: 400)
+    end
+
+    SaveShard.create(
+      name: shard_name,
+      description: description,
+      repository_url: repository_url,
+      homepage_url: homepage_url,
+      documentation_url: documentation_url,
+      license: license
+    ) do |operation, shard|
+      if shard
+        begin
+          storage = CrystalShards::StorageService.new
+          storage.upload_package_from_io(
+            shard_name: shard.name,
+            version: version,
+            content: package_content
+          )
+
+          SaveShardVersion.create(
+            shard_id: shard.id,
+            version: version,
+            checksum: computed_checksum,
+            released_at: Time.utc,
+            yanked: false
+          ) do |version_operation, shard_version|
+            if shard_version
+              json({
+                message:  "Shard uploaded successfully",
+                shard:    {
+                  id:   shard.id,
+                  name: shard.name,
+                },
+                version:  {
+                  id:       shard_version.id,
+                  version:  shard_version.version,
+                  checksum: shard_version.checksum,
+                },
+                checksum: computed_checksum,
+              }, status: 201)
+            else
+              json({
+                errors: version_operation.errors.map { |attr, msg| {attr.to_s, msg} },
+              }, status: 422)
+            end
+          end
+        rescue ex : Exception
+          json({
+            error: "Failed to upload package: #{ex.message}",
+          }, status: 500)
+        end
+      else
+        json({
+          errors: operation.errors.map { |attr, msg| {attr.to_s, msg} },
+        }, status: 422)
+      end
+    end
+  end
+end

--- a/apps/crystalshards/src/actions/api/shards/upload.cr
+++ b/apps/crystalshards/src/actions/api/shards/upload.cr
@@ -99,12 +99,12 @@ class Api::Shards::Upload < ApiAction
           ) do |version_operation, shard_version|
             if shard_version
               json({
-                message:  "Shard uploaded successfully",
-                shard:    {
+                message: "Shard uploaded successfully",
+                shard:   {
                   id:   shard.id,
                   name: shard.name,
                 },
-                version:  {
+                version: {
                   id:       shard_version.id,
                   version:  shard_version.version,
                   checksum: shard_version.checksum,

--- a/apps/crystalshards/src/models/shard_version.cr
+++ b/apps/crystalshards/src/models/shard_version.cr
@@ -6,6 +6,7 @@ class ShardVersion < BaseModel
     column commit_sha : String?
     column crystal_version : String?
     column metadata : JSON::Any?
+    column checksum : String?
 
     belongs_to shard : Shard
     has_many dependencies : Dependency

--- a/apps/crystalshards/src/services/storage_service.cr
+++ b/apps/crystalshards/src/services/storage_service.cr
@@ -15,10 +15,10 @@ module CrystalShards
 
       File.open(file_path, "r") do |file|
         @client.put_object(
-          bucket: MinIOConfig.settings.packages_bucket,
-          key: key,
-          body: file.gets_to_end,
-          metadata: HTTP::Headers{
+          MinIOConfig.settings.packages_bucket,
+          key,
+          file.gets_to_end,
+          {
             "Content-Type"    => "application/gzip",
             "X-Shard-Name"    => shard_name,
             "X-Shard-Version" => version,
@@ -29,14 +29,30 @@ module CrystalShards
       key
     end
 
+    # Upload a package from String content (for multipart uploads)
+    # Returns the object key (path in MinIO)
+    def upload_package_from_io(shard_name : String, version : String, content : String) : String
+      key = package_key(shard_name, version)
+
+      @client.put_object(
+        MinIOConfig.settings.packages_bucket,
+        key,
+        content,
+        {
+          "Content-Type"    => "application/gzip",
+          "X-Shard-Name"    => shard_name,
+          "X-Shard-Version" => version,
+        }
+      )
+
+      key
+    end
+
     # Download a package file from MinIO
     # Returns the file contents as a String
     def download_package(shard_name : String, version : String) : String
       key = package_key(shard_name, version)
-      response = @client.get_object(
-        bucket: MinIOConfig.settings.packages_bucket,
-        key: key
-      )
+      response = @client.get_object(MinIOConfig.settings.packages_bucket, key)
       response.body
     end
 
@@ -44,10 +60,7 @@ module CrystalShards
     def package_exists?(shard_name : String, version : String) : Bool
       key = package_key(shard_name, version)
       begin
-        @client.head_object(
-          bucket: MinIOConfig.settings.packages_bucket,
-          key: key
-        )
+        @client.head_object(MinIOConfig.settings.packages_bucket, key)
         true
       rescue ex : Awscr::S3::Exception
         false
@@ -75,10 +88,10 @@ module CrystalShards
 
         File.open(file_path, "r") do |file|
           @client.put_object(
-            bucket: MinIOConfig.settings.docs_bucket,
-            key: key,
-            body: file.gets_to_end,
-            metadata: HTTP::Headers{
+            MinIOConfig.settings.docs_bucket,
+            key,
+            file.gets_to_end,
+            {
               "Content-Type"    => content_type,
               "X-Shard-Name"    => shard_name,
               "X-Shard-Version" => version,
@@ -95,10 +108,7 @@ module CrystalShards
     # Get documentation file from MinIO
     def download_doc(shard_name : String, version : String, file_path : String) : String
       key = docs_key(shard_name, version, file_path)
-      response = @client.get_object(
-        bucket: MinIOConfig.settings.docs_bucket,
-        key: key
-      )
+      response = @client.get_object(MinIOConfig.settings.docs_bucket, key)
       response.body
     end
 
@@ -106,10 +116,7 @@ module CrystalShards
     def docs_exist?(shard_name : String, version : String) : Bool
       key = docs_key(shard_name, version, "index.html")
       begin
-        @client.head_object(
-          bucket: MinIOConfig.settings.docs_bucket,
-          key: key
-        )
+        @client.head_object(MinIOConfig.settings.docs_bucket, key)
         true
       rescue ex : Awscr::S3::Exception
         false


### PR DESCRIPTION
## Summary

Implements issue #1 - adds multipart file upload support to the CrystalShards package registry as an alternative to git-based publishing.

## Changes

### New Endpoint
- **POST /api/shards/upload** - Accepts multipart/form-data with package file and metadata
  - Required fields: name, version, repository_url, package (.tar.gz file)
  - Optional fields: description, homepage_url, documentation_url, license, checksum
  - Rate limited: 10 requests per hour

### Database Changes
- Added `checksum` column to `shard_versions` table (nullable String)
- Stores SHA256 hash of uploaded package for integrity verification

### Features
- **SHA256 checksum validation**: Client can provide checksum for verification, or it's computed automatically
- **Direct MinIO upload**: Package content uploaded directly to object storage from request body
- **File validation**: Ensures uploaded file has `.tar.gz` extension
- **Comprehensive error handling**: Clear error messages for missing fields, invalid files, checksum mismatches

### Testing
- 8 comprehensive test cases covering:
  - Successful uploads with all fields
  - Required field validation
  - File extension validation
  - Checksum validation (both provided and auto-computed)
  - Content-Type validation
  - Optional field handling
  - Version creation with checksum storage

### API Fixes
- Fixed `awscr-s3` API usage throughout `StorageService` (positional arguments, not named)
- Affected methods: `put_object`, `get_object`, `head_object`

### Documentation
- Updated OpenAPI spec with complete multipart endpoint documentation
- Includes request/response schemas, examples, error codes

## Benefits

1. **Faster publishing** - No git clone required, direct upload to storage
2. **Private repos** - Support for packages not in public repositories
3. **Better UX** - Simple HTTP multipart upload instead of git workflow
4. **Integrity verification** - SHA256 checksums ensure package hasn't been tampered with

## Testing

All tests compile successfully. To run:

```bash
crystal spec spec/requests/api/shards/upload_spec.cr
```

## Related Issues

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)